### PR TITLE
🔧 Fix GitHub Actions workflow context access issues

### DIFF
--- a/.github/workflows/ci-cd-dev.yml
+++ b/.github/workflows/ci-cd-dev.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    env:
-      IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service-dev:${{ github.sha }}-${{ github.run_id }}-dev
 
     steps:
       - name: Checkout code
@@ -29,6 +27,8 @@ jobs:
         run: npm test -- --passWithNoTests
 
       - name: Build Docker image
+        env:
+          IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service-dev:${{ github.sha }}-${{ github.run_id }}-dev
         run: docker build --platform linux/amd64 --no-cache -t $IMAGE_TAG -f docker/Dockerfile.cloudrun .
 
       - name: Authenticate to Google Cloud
@@ -40,9 +40,13 @@ jobs:
         run: gcloud auth configure-docker us-central1-docker.pkg.dev
 
       - name: Push Docker image
+        env:
+          IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service-dev:${{ github.sha }}-${{ github.run_id }}-dev
         run: docker push $IMAGE_TAG
 
       - name: Deploy to Cloud Run
+        env:
+          IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service-dev:${{ github.sha }}-${{ github.run_id }}-dev
         run: |
           gcloud run deploy algorhythm-service-dev \
             --image $IMAGE_TAG \

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -23,8 +23,6 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    env:
-      IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service:${{ github.sha }}-${{ github.run_id }}
 
     steps:
       - name: Checkout code
@@ -46,6 +44,8 @@ jobs:
         run: npm run test:e2e -- --passWithNoTests
 
       - name: Build Docker image
+        env:
+          IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service:${{ github.sha }}-${{ github.run_id }}
         run: docker build --platform linux/amd64 --no-cache -t $IMAGE_TAG -f docker/Dockerfile.cloudrun .
 
       - name: Authenticate to Google Cloud
@@ -57,9 +57,13 @@ jobs:
         run: gcloud auth configure-docker us-central1-docker.pkg.dev
 
       - name: Push Docker image
+        env:
+          IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service:${{ github.sha }}-${{ github.run_id }}
         run: docker push $IMAGE_TAG
 
       - name: Deploy to Cloud Run
+        env:
+          IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service:${{ github.sha }}-${{ github.run_id }}
         run: |
           gcloud run deploy algorhythm-service \
             --image $IMAGE_TAG \

--- a/.github/workflows/ci-cd-stg.yml
+++ b/.github/workflows/ci-cd-stg.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    env:
-      IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service-staging:${{ github.sha }}-${{ github.run_id }}-stg
 
     steps:
       - name: Checkout code
@@ -29,6 +27,8 @@ jobs:
         run: npm test -- --passWithNoTests
 
       - name: Build Docker image
+        env:
+          IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service-staging:${{ github.sha }}-${{ github.run_id }}-stg
         run: docker build --platform linux/amd64 --no-cache -t $IMAGE_TAG -f docker/Dockerfile.cloudrun .
 
       - name: Authenticate to Google Cloud
@@ -40,9 +40,13 @@ jobs:
         run: gcloud auth configure-docker us-central1-docker.pkg.dev
 
       - name: Push Docker image
+        env:
+          IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service-staging:${{ github.sha }}-${{ github.run_id }}-stg
         run: docker push $IMAGE_TAG
 
       - name: Deploy to Cloud Run
+        env:
+          IMAGE_TAG: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/algorhythm-repo/algorhythm-service-staging:${{ github.sha }}-${{ github.run_id }}-stg
         run: |
           gcloud run deploy algorhythm-service-staging \
             --image $IMAGE_TAG \


### PR DESCRIPTION
## 🎯 **Problem**
GitHub Actions workflows were showing 6 context access warnings due to using secrets in job-level `env` sections.

## 🔧 **Solution**
- Move `IMAGE_TAG` from job-level `env` to step-level `env` in all workflows
- Resolves 6 context access warnings in ci-cd-dev.yml, ci-cd-stg.yml, ci-cd-prod.yml
- Maintains all existing functionality while following GitHub Actions best practices

## 📊 **Expected Results**
- ✅ 6 problems resolved (2 per workflow file)
- ✅ No more context access warnings
- ✅ Workflows function identically
- ✅ Follows GitHub Actions best practices

## 🧪 **Testing**
- [ ] Verify GitHub Actions interface shows 0 problems
- [ ] Test workflow execution
- [ ] Confirm deployments work correctly