### PR TITLE
fix(ci): add missing jest-e2e.json config

### DIFF
--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}


### PR DESCRIPTION
Add test/jest-e2e.json to unblock production workflow. Resolves 'Can't find a root directory while resolving a config file path' error.